### PR TITLE
Make response output JSON and improve install flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,14 @@ jobs:
 
       - name: Configure (Linux/macOS)
         if: matrix.os != 'windows-latest'
-        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="dev"
+          if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+            version="${GITHUB_REF_NAME#v}"
+          fi
+          cmake -S . -B build -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DPINGA_VERSION="${version}"
 
       - name: Build (Linux/macOS)
         if: matrix.os != 'windows-latest'
@@ -68,7 +75,13 @@ jobs:
       - name: Configure (Windows)
         if: matrix.os == 'windows-latest'
         shell: msys2 {0}
-        run: cmake -S . -B build -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }}
+        run: |
+          set -euo pipefail
+          version="dev"
+          if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+            version="${GITHUB_REF_NAME#v}"
+          fi
+          cmake -S . -B build -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DPINGA_VERSION="${version}"
 
       - name: Build (Windows)
         if: matrix.os == 'windows-latest'

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build/
+build-user/
 CMakeFiles/
 CMakeCache.txt
 *.o

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.20)
 
-project(pinga C)
+project(pinga LANGUAGES C)
 
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED ON)
@@ -12,8 +12,13 @@ add_executable(pinga
   src/jsmn.c
 )
 
+set(PINGA_VERSION "dev" CACHE STRING "Version string")
+
 target_compile_options(pinga PRIVATE -Wall -Wextra -Wpedantic)
 target_link_libraries(pinga PRIVATE CURL::libcurl)
+target_compile_definitions(pinga PRIVATE PINGA_VERSION="${PINGA_VERSION}")
+
+install(TARGETS pinga RUNTIME DESTINATION bin)
 
 enable_testing()
 find_package(Python3 REQUIRED COMPONENTS Interpreter)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,8 @@
-.PHONY: build run test test-mock clean
+.PHONY: build run test test-mock install uninstall clean
+
+PREFIX ?=
+USER_PREFIX := $(HOME)/.local
+SYSTEM_PREFIX := /usr/local
 
 build:
 	cmake -S . -B build
@@ -16,5 +20,42 @@ endif
 test-mock: build
 	python3 scripts/mock_test.py
 
+install: build
+	@set -e; \
+	install_build_dir=build; \
+	if [ -f build/install_manifest.txt ] && [ ! -w build/install_manifest.txt ]; then \
+		echo "build/install_manifest.txt is not writable; using build-user for install."; \
+		install_build_dir=build-user; \
+		cmake -S . -B "$$install_build_dir"; \
+		cmake --build "$$install_build_dir"; \
+	fi; \
+	if [ -n "$(PREFIX)" ]; then \
+		prefix="$(PREFIX)"; \
+	elif [ -d "$(USER_PREFIX)/bin" ]; then \
+		prefix="$(USER_PREFIX)"; \
+	else \
+		echo "User prefix $(USER_PREFIX)/bin not found; installing to $(SYSTEM_PREFIX)."; \
+		echo "You may need to run: sudo make install"; \
+		prefix="$(SYSTEM_PREFIX)"; \
+	fi; \
+	cmake --install "$$install_build_dir" --prefix "$$prefix"
+
+uninstall:
+	@set -e; \
+	manifest=""; \
+	for dir in build build-user; do \
+		if [ -f "$$dir/install_manifest.txt" ]; then \
+			manifest="$$dir/install_manifest.txt"; \
+			break; \
+		fi; \
+	done; \
+	if [ -z "$$manifest" ]; then \
+		echo "No install_manifest.txt found in build/ or build-user/. Run 'make install' first."; \
+		exit 1; \
+	fi; \
+	while IFS= read -r file; do \
+		rm -f "$$file"; \
+	done < "$$manifest"
+
 clean:
-	rm -rf build
+	rm -rf build build-user

--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ I’d rather drink a lot of pinga than open heavy tools like Postman._
 - Supports method, headers, query params, path params, and body
 - `payload` can be a string or any JSON value
 - `payload_file` lets you send body from a file
-- Simple CLI output: prints response body to stdout (pipe to `jq` for pretty JSON)
+- JSON output: prints `status`, `headers`, and `body` (valid JSON for `jq`)
+- `--exclude-response-headers` prints only the raw response body
+- `--version` prints the CLI version
 
 ## Quick start
 
@@ -43,6 +45,34 @@ Or:
 
 ```bash
 make build
+```
+
+Install:
+
+```bash
+make install
+```
+
+Default install location is `~/.local/bin` when it exists; otherwise it falls back to `/usr/local` (sudo may be required).
+
+Custom prefix:
+
+```bash
+make install PREFIX=/opt/pinga
+```
+
+Version:
+
+```bash
+./build/pinga --version
+```
+
+Release builds use the Git tag (e.g. `v1.2.3`) as the reported version.
+
+Uninstall:
+
+```bash
+make uninstall
 ```
 
 ## Dependencies
@@ -108,6 +138,12 @@ Pretty-print JSON output:
 
 ```bash
 ./build/pinga config.json | jq
+```
+
+Exclude response headers:
+
+```bash
+./build/pinga --exclude-response-headers config.json
 ```
 
 Exit codes (with `--silent`, suppresses response body output):

--- a/scripts/mock_test.py
+++ b/scripts/mock_test.py
@@ -57,7 +57,7 @@ def run():
         tmp_path = tmp.name
 
     try:
-        cmd = ["./build/pinga", tmp_path]
+        cmd = ["./build/pinga", "--exclude-response-headers", tmp_path]
         result = subprocess.run(cmd, capture_output=True, text=True)
         if result.returncode != 0:
             raise SystemExit(result.stderr.strip() or "pinga failed")


### PR DESCRIPTION
  - emit status, headers, and body as JSON by default
  - add --exclude-response-headers for raw body output
  - add --version flag and pass release version via CI
  - improve make install/uninstall with user prefix fallback
  - ignore build-user directory